### PR TITLE
Remove table layout from how-to template

### DIFF
--- a/how-to/about-howto.md
+++ b/how-to/about-howto.md
@@ -49,14 +49,7 @@ Make sure you meet the following prerequisites before following the steps:
 
 ### About the "Step by step guide" sections
 
-When you are explaining steps in a process, it can often be useful to include a screenshot for each part of the process.
-What can often happen is that when you try to insert a graphic or screenshot into the flow of the procedure, it breaks the procedural content up and makes the instructions difficult to read.
-
-In the `template-howto.adoc` file, you'll notice the tabular step format in the Step-by-step section of the template.
-The tabular format allows you to add in your procedural steps right next to the screenshot and reference steps with call-outs.
-
-If you procedural steps do not require screenshots, then you can default to an ordered list.
-You can also get this structure in Markdown, but you may need to resort to HTML tables. For Markdown, keep the list as an Ordered list.
+..
 
 ## How-to Article Examples
 

--- a/how-to/template-howto.adoc
+++ b/how-to/template-howto.adoc
@@ -34,7 +34,9 @@ Lead-in sentence for an ordered list:
 
 === Descriptive title for code snippet
 
-Lead in sentence explaining the code snippet. E.g.: Run the `apt` command to install the Asciidoctor package and check the version.
+Lead in sentence explaining the code snippet. E.g.: 
+
+Run the `apt` command to install the Asciidoctor package and check the version.
 
 [source]
 ----

--- a/how-to/template-howto.adoc
+++ b/how-to/template-howto.adoc
@@ -20,26 +20,22 @@ Make sure you meet the following prerequisites before starting the how-to steps:
 
 == Step-by-step guide
 
-// If your how-to is simple (it doesn't contain screenshots or code samples) you can use an ordered list for your procedure. Otherwise use the step table.
+=== Descriptive title
 
-[cols="a,a,a" options="header,autowidth"]
-|===
-|Step
-|Task
-|Screenshot or example
+// When an image, such as a screenshot, is quicker to interpret than descriptive text, put the screenshot first, otherwise lead with the text.
 
-|1
-|Lead-in sentence for an ordered list:
+image::https://upload.wikimedia.org/wikipedia/commons/3/35/Tux.svg[Tux,250,350]
+
+Lead-in sentence for an ordered list:
 
 . Step 1
 . Step 2
 . Step 3
 
-|image::https://upload.wikimedia.org/wikipedia/commons/3/35/Tux.svg[Tux,250,350]
+=== Descriptive title for code snippet
 
-|2
-|Run the `apt` command to install the Asciidoctor package and check the version.
-|
+Lead in sentence explaining the code snippet. E.g.: Run the `apt` command to install the Asciidoctor package and check the version.
+
 [source]
 ----
 $ sudo apt install asciidoctor
@@ -47,5 +43,3 @@ $ sudo apt install asciidoctor
 $ asciidoctor --version
 Asciidoctor 1.5.6.2 [https://asciidoctor.org]
 ----
-
-|===


### PR DESCRIPTION
Fixes #105, partially addresses #57.
I feel we shouldn't be recommending the use of tables to address image alignment. My reasons:

* Responsive web design principles suggest that we shouldn't assume the target screen size, and using tables locks us into a specific screen size.
* Applying layout recommendations contradicts the Google's style guide that we have decided to follow.
* TheGoodDocs templates should focus should be on content rather than style (although we might cover style elsewhere).

Note: I do think the use of tables for presenting images next to instructions is a good idea, but I think there are other ways to do it too, which should be considered as well.