### PR TITLE
Update about-quickstart.md

### DIFF
--- a/api-quickstart/about-quickstart.md
+++ b/api-quickstart/about-quickstart.md
@@ -13,15 +13,15 @@
 
 ### The Main Body Should Follow These Guidelines.
 
-* Start by telling users what the quickstart will do. What task does this guide help the reader to complete?
-* It should explain the basic operations that most users will want to perform on the site, or the operations they will perform when they use the API.
+* Start by telling users what the quickstart does. What task does this guide help the reader complete?
+* It should explain the basic operations that most users perform on the site, or the operations they might perform using the API.
 * Steps should be explained in the most logical order to complete a task
 * Each step should contain all the information necessary to complete it. It should exclude any extraneous information.
 * A step should include code samples (examples) that users can copy and paste, if executing code is necessary. Each code sample should be explained in comments that follow directly after the example, so newcomers can quickly understand how the API works.
 
 ### The Quickstart Should Not Include:
 
-* Setup information. (This means info about everything you have to do to make your work environment compatible and ready for the API.) Sometimes setup and quickstart type information end up together in a single volume called a "Getting Started" guide (or something similar). That's not necessarily wrong, but there are advantages to keeping the two types of information separate; namely, there will be times when users no longer need the quickstart lesson, but they want the setup information because they are creating a work environment on a new machine.
+* Setup information. (This means info about everything you have to do to make your work environment compatible and ready for the API.) Sometimes setup and quickstart type information end up together in a single volume called a "Getting Started" guide (or something similar). That's not necessarily wrong, but there are advantages to keeping the two types of information separate; namely, times when users no longer need the quickstart lesson, but want the setup information to create a work environment on a new machine.
 * Things that belong in the reference section, like authentication, throttling, error codes, a complete description of any feature.
 * Things that belong in the overview (a general description of the product; what it can do; what it can't do)
 

--- a/api-quickstart/about-quickstart.md
+++ b/api-quickstart/about-quickstart.md
@@ -7,15 +7,16 @@
 ## Contents of Your Quickstart
 
 ### Prerequisites
-* What knowledge do I need before I begin? What tasks must be completed (installation, configuring the environment?)
+* What knowledge do I need before I begin? 
+* What tasks must be completed (installation, configuring the environment?)
 * Where to get tokens or API keys, etc. if needed
 
 ### The Main Body Should Follow These Guidelines.
 
 * Start by telling users what the quickstart will do. What task does this guide help the reader to complete?
-* It should be explaining the basic operations that most users will want to perform on the site, or the operations they will perform when they use the API.
+* It should explain the basic operations that most users will want to perform on the site, or the operations they will perform when they use the API.
 * Steps should be explained in the most logical order to complete a task
-* Each step should contain all the information necessary to complete it. And the Quickstart should not contain any additional info that is not needed--because it will be easier to understand if it is as brief as possible.
+* Each step should contain all the information necessary to complete it. It should exclude any extraneous information.
 * A step should include code samples (examples) that users can copy and paste, if executing code is necessary. Each code sample should be explained in comments that follow directly after the example, so newcomers can quickly understand how the API works.
 
 ### The Quickstart Should Not Include:


### PR DESCRIPTION
Made the changes suggested in #38. Also, a couple of changes I'd like to make as well, but need an opinion before doing so. A few sentences like the following use `will`. I suggest removing or replacing the word. For example:

> It should explain the basic operations that most users will want to perform on the site, or the operations they will perform when they use the API. 

It should explain the basic operations that most users perform on the site, or the operations they perform when they use the API. 

> Start by telling users what the quickstart will do

Start by telling users what the quickstart does. 

Basically, a few tense changes. There are a couple more `will`s in the document. I'll make these changes if(/when) a maintainer accepts them.