### PR TITLE
update: sentence case in titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,22 @@ Here we provide tips for using these templates.
 
 The templates are categorised in line with standard [DITA](http://docs.oasis-open.org/dita/dita/v1.3/errata02/os/complete/part3-all-inclusive/archSpec/technicalContent/dita-technicalContent-InformationTypes.html#dita_technicalContent_InformationTypes) documentation types:
 
-**Concept**: Describes how and why things work. Concepts are normally written to help the reader understand a technology, prior to using it.
+**Concept**: Describes how and why things work. 
+Concepts are normally written to help the reader understand a technology, prior to using it.
 
-**Task**: Gives specific instructions about how to get something done. In practice, Tasks tend to have a specific goal and usually consist of a set of numbered steps that the reader can follow to achieve the goal.
+**Task**: Gives specific instructions about how to get something done. 
+In practice, Tasks tend to have a specific goal and usually consist of a set of numbered steps that the reader can follow to achieve the goal.
 
-**Reference**: Contains structured information or specifications that users need to make a product work. Reference sections should comprehensively catalog data such as functions and their parameters, return codes and error messages.
+**Reference**: Contains structured information or specifications that users need to make a product work. 
+Reference sections should comprehensively catalog data such as functions and their parameters, return codes and error messages.
 
 Our templates follow these documentation types, and you should find that your information naturally fits into them as you write.
 
 ## How to use these templates
 
-We like to compare documentation types to aisles in a grocery store. Each aisle includes related templates, which you can think of as ingredients. Use these ingredients in documentation cookbooks to whip up docs for your readers.
+We like to compare documentation types to aisles in a grocery store. 
+Each aisle includes related templates, which you can think of as ingredients. 
+Use these ingredients in documentation cookbooks to whip up docs for your readers.
 
 When writing your documentation, it helps to think about the following:
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@ This repository contains best-practice templates to help build documentation for
 Here we provide tips for using these templates.
 
 ## Core documentation types
+
 The templates are categorised in line with standard [DITA](http://docs.oasis-open.org/dita/dita/v1.3/errata02/os/complete/part3-all-inclusive/archSpec/technicalContent/dita-technicalContent-InformationTypes.html#dita_technicalContent_InformationTypes) documentation types:
 
-**Concept**: Describes how and why things work. Concepts are normally written to help the reader understand a technology, prior to using it. 
+**Concept**: Describes how and why things work. Concepts are normally written to help the reader understand a technology, prior to using it.
 
-**Task**: Gives specific instructions about how to get something done. In practice, Tasks tend to have a specific goal and usually consist of a set of numbered steps that the reader can follow to achieve the goal. 
+**Task**: Gives specific instructions about how to get something done. In practice, Tasks tend to have a specific goal and usually consist of a set of numbered steps that the reader can follow to achieve the goal.
 
 **Reference**: Contains structured information or specifications that users need to make a product work. Reference sections should comprehensively catalog data such as functions and their parameters, return codes and error messages.
 
@@ -23,7 +24,7 @@ When writing your documentation, it helps to think about the following:
 
 * Who are you writing for?
 * What will they be trying to accomplish when they read the documentation?
-* The information type. Is it a concept, a task or reference? 
+* The information type. Is it a concept, a task or reference?
 
 ## The templates
 
@@ -31,7 +32,7 @@ Templates we currently offer:
 
 | Template name | Documentation type |
 | ---------------------- | ------- |
-API Project overview | Concept 
+API Project overview | Concept
 API Quickstart | Concept, Task
 API Reference | Reference
 Discussion | Concept
@@ -47,6 +48,3 @@ Logging reference | Reference
 | API reference | One chapter in your full API documentation | Reference entries (multiple reference) + error information (reference) + throttling (concept) + authentication (task) |
 | API guide: good | The starter set for API docs | API project overview + setup instructions (task) + Reference section (see recipe above) + Quickstart |
 | API guide: better | Improved API docs, after learning about users | API project overview + setup instructions (task) + Reference(s) + Quickstart + How-to(s) |
-
-
-

--- a/api-overview/about-overview.md
+++ b/api-overview/about-overview.md
@@ -1,6 +1,6 @@
-# The Overview
+# The overview
 
-### When Do I Need an Overview?
+## When do I need an overview?
 
 Your API documentation should include an overview document. This document tells potential users or buyers what they might want to know before adoption.
 
@@ -8,15 +8,15 @@ Many users install or plug into your service immediately because they are alread
 
 There are other groups, however, who need to assess your product in order to decide whether they want to use it. For example, managers responsible for a business decision or engineers responsible for a technical assessment of your product. People in these groups might decide to not adopt your product unless you provide an overview that answers their questions.
 
-## Content of Your Overview
+## Content of your overview
 
-### Who is This Overview For?
+### Who is this overview for?
 
 * Are you writing only for developers? For managers?
 * Are you writing only for people who have a certain problem to solve?
 * Is it intended for a particular industry.
 
-### Body of the Overview
+### Body of the overview
 
 Contains information that helps the developer or decision-maker get oriented to the API. Answers these questions.
 
@@ -34,9 +34,9 @@ Contains information that helps the developer or decision-maker get oriented to 
 * What comes next? Do you want to direct users to the quickstart, to try it out?
 * How does one get started using the API?
 
-## More Information
+## More information
 
-### Overview Examples
+### Overview examples
 
 * **Chrome Native Client**. This overview explains and engine that allows C++ to run in the browser, including why it is a good solution for engineers who want to rework a desktop app and make it usable as a web app.
     https://developer.chrome.com/native-client/overview

--- a/api-quickstart/about-quickstart.md
+++ b/api-quickstart/about-quickstart.md
@@ -1,17 +1,17 @@
-## What is a Quickstart
+## What is a quickstart
 
 * It should be a clear, concise, ordered step-by-step procedure.
 * It should describe the easiest way for them to achieve a result that shows off the capabilities of your product.
 * It should not delve into optimizations or advanced use cases.
 
-## Contents of Your Quickstart
+## Contents of your quickstart
 
 ### Prerequisites
 * What knowledge do I need before I begin? 
 * What tasks must be completed (installation, configuring the environment?)
 * Where to get tokens or API keys, etc. if needed
 
-### The Main Body Should Follow These Guidelines.
+### The main body should follow these guidelines
 
 * Start by telling users what the quickstart does. What task does this guide help the reader complete?
 * It should explain the basic operations that most users perform on the site, or the operations they might perform using the API.
@@ -19,7 +19,7 @@
 * Each step should contain all the information necessary to complete it. It should exclude any extraneous information.
 * A step should include code samples (examples) that users can copy and paste, if executing code is necessary. Each code sample should be explained in comments that follow directly after the example, so newcomers can quickly understand how the API works.
 
-### The Quickstart Should Not Include:
+### The quickstart should not include
 
 * Setup information. (This means info about everything you have to do to make your work environment compatible and ready for the API.) Sometimes setup and quickstart type information end up together in a single volume called a "Getting Started" guide (or something similar). That's not necessarily wrong, but there are advantages to keeping the two types of information separate; namely, times when users no longer need the quickstart lesson, but want the setup information to create a work environment on a new machine.
 * Things that belong in the reference section, like authentication, throttling, error codes, a complete description of any feature.
@@ -29,7 +29,7 @@
 
 * What comes next?
 
-## Links to Examples
+## Links to examples
 
 * **Jekyll**. This SSG offers an excellent quickstart. Note that the setup info is in a separate document, but it is linked in the first step. https://jekyllrb.com/docs/
 

--- a/api-quickstart/about-quickstart.md
+++ b/api-quickstart/about-quickstart.md
@@ -7,6 +7,7 @@
 ## Contents of your quickstart
 
 ### Prerequisites
+
 * What knowledge do I need before I begin? 
 * What tasks must be completed (installation, configuring the environment?)
 * Where to get tokens or API keys, etc. if needed

--- a/api-quickstart/api-quickstart.md
+++ b/api-quickstart/api-quickstart.md
@@ -8,7 +8,7 @@ Make sure you meet the following prerequisites before starting the tutorial step
 * Prerequisite two
 * etc
 
-## Get Started
+## Get started
 
 ## Step 1 - <One-sentence description of the step.>
 

--- a/api-reference/about-api-reference.md
+++ b/api-reference/about-api-reference.md
@@ -1,6 +1,6 @@
-# The API Reference Entry
+# The API reference entry
 
-## About the Reference Section
+## About the reference section
 
 The reference section is generally a collection of short entries, arranged in alphabetical order. This template addresses the individual reference entry that you create for a single endpoint. 
 
@@ -8,10 +8,9 @@ The reference section is important for API documentation. New users will start w
 
 The reference section should contain a full listing of endpoints, methods, and parameters
 
-## The General Contents
+## The general contents
 
-
-### Reference Entries
+### Reference entries
 
 Each reference listing should ideally contain:
 
@@ -23,8 +22,7 @@ Each reference listing should ideally contain:
 * An example response
 * Response schema
 
-
-## Best Practices for Reference Docs
+## Best practices for reference docs
 
 Each detailed reference entry should contain all the information a user might need to know when using the feature.
 

--- a/api-reference/api-reference.md
+++ b/api-reference/api-reference.md
@@ -1,10 +1,4 @@
-
-
-
-
-
-
-## Endpoint name 
+# Endpoint name
 
 Method | syntax
 ----- | ----------
@@ -12,23 +6,23 @@ GET | base_url/endpoint/etc.
 
 <!-- Delete this comment after the method and syntax above have been replaced with yours. -->
 
-### Description 
+## Description
 
 <!-- Enter a few sentences of description. (What is it for, and what can it do?) -->
 
-Parameters 
+Parameters
 
-Name | type | Req. | Description 
+Name | type | Req. | Description
 ---- | ----- | ----- | --------------------
 Parameter_one | string | Y |  Stores the customer name
-Parameter_two | int  | N | Stores a postal code, like the U.S. ZIP code. 
+Parameter_two | int  | N | Stores a postal code, like the U.S. ZIP code.
 
 <!-- Delete this comment after deleting the two example rows above and including rows for all your parameters. -->
 <!-- If one of the parameters has a set of sub-parameters you can create a table or bulleted list for that, but proceed with caution. If the API is extremely complex, there might be an easier way to do your reference section than writing markup by hand. -->
 
-### Examples 
+## Examples
 
-#### Request 
+### Request
 
 ```HTTP
 <!--  A cut-and-paste working request, if at all possible. Not one with values replaced by their names, such as "ID." -->
@@ -37,14 +31,11 @@ Parameter_two | int  | N | Stores a postal code, like the U.S. ZIP code.
 
 <!-- Follow with comments to explain what each part of the request is doing -->
 
-#### Response
+### Response
 
 ```HTTP
 <!--  An actual response returned by this endpoint for the request just above.  -->
 
 ```
 
-<!-- Write a comment explainig the response, if it would be helpful. For a response with a complicated schema, create a table like the one used above for the request.  --> 
-
-
-
+<!-- Write a comment explainig the response, if it would be helpful. For a response with a complicated schema, create a table like the one used above for the request.  -->

--- a/contribute.md
+++ b/contribute.md
@@ -1,19 +1,18 @@
-
-## How to Contribute
+# How to contribute
 
 We’d love your help.
 
-*   Have you noticed something that could be improved?
-*   Want to share your tech writing expertise?
-*   Do you have material you’d like to integrate into our baseline?
-*   Do you know of research which should be referenced?
-*   Something else?
+* Have you noticed something that could be improved?
+* Want to share your tech writing expertise?
+* Do you have material you’d like to integrate into our baseline?
+* Do you know of research which should be referenced?
+* Something else?
 
 Please do reach out to us with your ideas.
 
 ## Contact us
 
-* Slack: [https://thegooddocs.slack.com/](https://thegooddocs.slack.com/) 
+* Slack: [https://thegooddocs.slack.com/](https://thegooddocs.slack.com/)
 * Email list: [https://groups.io/g/thegooddocsproject/](https://groups.io/g/thegooddocsproject/)
 
 ## About contributing
@@ -26,7 +25,7 @@ By contributing to this project we expect you to agree to the [Developer Certifi
 
 You can improve our documentation by submitting a pull request to our [Github templates repo](https://github.com/thegooddocsproject/templates). Here is [how](https://guides.github.com/activities/hello-world/).
 
-For all but minor typos, it is s a good idea to discuss your proposed changes with us before submitting a pull request. 
+For all but minor typos, it is s a good idea to discuss your proposed changes with us before submitting a pull request.
 
 1. Create an issue in the [github  tracker](https://github.com/thegooddocsproject/templates/issues).
 2. Be as specific as you can in the scope of work within the issue. Be sure to include the "why" for considering the work.
@@ -35,8 +34,8 @@ For all but minor typos, it is s a good idea to discuss your proposed changes wi
 
 ### Issue tracker
 
-We track outstanding work in our [github  tracker](https://github.com/thegooddocsproject/templates/issues). To keep our issue tracker manageable, we prefer you discuss suggestions or issues in one of our forums, typically our email list, before adding an issue to the tracker. 
+We track outstanding work in our [github  tracker](https://github.com/thegooddocsproject/templates/issues). To keep our issue tracker manageable, we prefer you discuss suggestions or issues in one of our forums, typically our email list, before adding an issue to the tracker.
 
-### Style Guide
+### Style guide
 
 We use the [Google Style Guide](http://google.github.io/styleguide/) and American spelling, as per the [Merriam-Webster Online](https://www.merriam-webster.com/)  dictionary. If you’re used to working with such reference books, that’s great; if not, please contribute anyway, a tech writer will likely update your contribution later.

--- a/discussion/about-discussion.md
+++ b/discussion/about-discussion.md
@@ -1,10 +1,10 @@
-# The Discussion Article
+# The discussion article
 
-## When Do I Need a Discussion Article?
+## When do I need a discussion article?
 
 Discussions provide understanding-oriented background information and context-specific knowledge on a particular topic.
 
-The goals of a Discussion article are understanding-oriented, not procedural or learning.
+The goals of a discussion article are understanding-oriented, not procedural or learning.
 
 Discussion articles work well when they deliver the following types of information:
 
@@ -13,11 +13,9 @@ Discussion articles work well when they deliver the following types of informati
 * They suggest alternative approaches or different ways of thinking about a customer challenge or technical topic
 * They allow your audience to make connections between related concepts so they can form a better understanding of the subject.
 
+## Content of your discussion article
 
-
-## Content of Your Discussion Article
-
-### About the "Overview" Section
+### About the "Overview" section
 
 Summarise what the reader will get from reading the discusison article.
 
@@ -33,26 +31,26 @@ If you plan on using a whole lot of terms that might not be familiar to your rea
 
 Declaring them here lets you use any abbreviated forms of the terminology you're using in the body of the discussion
 
-### Structuring Discussion Articles
+### Structuring discussion articles
 
 Think about structuring discussion topics like you would a presentation to a group of folks who don't know anything about your chosen subject.
 Your discussion should introduce ideas gradually so your audience can grow their understanding of the concepts in your discussion.
 
-It can be easy to blend Discussions with other types of content, like How-to or Reference articles.
+It can be easy to blend discussions with other types of content, like How-to or Reference articles.
 Here are a few tips to avoid mixing documentatation types:
 
 * Avoid instructions, procedures, or any content that doesn't focus solely on building upon the conceptual understanding of the discussion topic.
-* If you find yourself writing steps or describing how to do something in detail in your Discussion article, chances are you need to shift your focus away from the "doing" and remind yourself of the main goals.
+* If you find yourself writing steps or describing how to do something in detail in your discussion article, chances are you need to shift your focus away from the "doing" and remind yourself of the main goals.
 
-Here are some clues that your Discussion article is not staying on-topic.
+Here are some clues that your discussion article is not staying on-topic.
 
 | Clue | Solution |
 |-----------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | You start to write steps to achieve something that you're describing in your topic. | Look for opportunities to link to other topics that complement your discussion content. Link to these articles in-line or at the end of the document in the "Where to next" section. |
 | You think that inserting a tutorial video about the discussion item directly into the discussion is necessary. | Link to the video in the "Where to next" section, so your audience doesn't get distracted by the video. |
-| You begin including YAML and JSON structures of end-points that you can call in your conceptual API discussion. | You are mixing too much reference content into your Discussion article. Bring the focus back to understanding the structures, not documenting all the things you can do with them. If your discussion article still needs to link back to the API, you can add the link with a brief explanation to the Related Articles section.  |
+| You begin including YAML and JSON structures of end-points that you can call in your conceptual API discussion. | You are mixing too much reference content into your discussion article. Bring the focus back to understanding the structures, not documenting all the things you can do with them. If your discussion article still needs to link back to the API, you can add the link with a brief explanation to the Related Articles section.  |
 
-## Discussion Article Examples
+## Discussion article examples
 
 * **Example 1**.
 

--- a/discussion/about-discussion.md
+++ b/discussion/about-discussion.md
@@ -36,7 +36,7 @@ Declaring them here lets you use any abbreviated forms of the terminology you're
 Think about structuring discussion topics like you would a presentation to a group of folks who don't know anything about your chosen subject.
 Your discussion should introduce ideas gradually so your audience can grow their understanding of the concepts in your discussion.
 
-It can be easy to blend discussions with other types of content, like How-to or Reference articles.
+It can be easy to blend discussions with other types of content, like how-to or reference articles.
 Here are a few tips to avoid mixing documentatation types:
 
 * Avoid instructions, procedures, or any content that doesn't focus solely on building upon the conceptual understanding of the discussion topic.

--- a/how-to/about-how-to.md
+++ b/how-to/about-how-to.md
@@ -1,6 +1,6 @@
-# The How-to Article
+# The how-to article
 
-### When Do I Need a How-to Article?
+## When do I need a how-to article?
 
 How-to articles take the reader through a series of steps required to solve a specific, real-world problem.
 Think of them as recipes for getting stuff done!
@@ -13,9 +13,9 @@ How-to articles are often confused with tutorials, which is not the case as they
 How-to articles are used by those who have experience with the product and need a specific question answered.
 New users who want to solve a problem instantly can also benefit from how-to articles provided they are well-written and clearly state any prerequisite knowledge required to complete the how-to.
 
-## Content of Your How-to Article
+## Content of your how-to article
 
-### About the "Overview" Section
+### About the "Overview" section
 
 Summarise what the reader will get from reading the how-to articles.
 
@@ -25,7 +25,7 @@ Creating a good overview comes down to thinking about who is going to be using i
 * Are you writing only for people who have a certain problem to solve?
 * Is it intended for a particular industry?
 
-### About the "Before you Start" section
+### About the "Before you start" section
 
 Have you ever got halfway through a how-to, only to discover you need to go and read other documentation before you can continue?
 This section is designed to prevent this from happening in the first place.
@@ -49,7 +49,7 @@ Make sure you meet the following prerequisites before following the steps:
 
 ..
 
-## How-to Article Examples
+## How-to article examples
 
 * **Example 1**.
 

--- a/how-to/template-how-to.md
+++ b/how-to/template-how-to.md
@@ -26,7 +26,7 @@ Make sure you meet the following prerequisites before starting the how-to steps:
 
 Brief instructions explaining how to interpret the image.
 
-### Step 2: Optional: Title for step - ordered list
+### Step 2: Optional: title for step - ordered list
 
 Lead-in sentence for an ordered list:
 
@@ -34,7 +34,7 @@ Lead-in sentence for an ordered list:
 1. Substep B
 1. Substep C
 
-### Step 3: Optional: Title for step - code snippet
+### Step 3: Optional: title for step - code snippet
 
 Lead in sentence explaining the code snippet. E.g.: 
 

--- a/logging/about-logging.md
+++ b/logging/about-logging.md
@@ -1,14 +1,14 @@
-# The Logging Article
+# The logging article
 
-### When Do I Need a Logging Article?
+## When do I need a logging article?
 
 A logging article is a special type of template that is used only to describe log pipelines specific to your application.
 
-This article type aligns itself closely with the Reference content type, so the same content guidelines apply.
+This article type aligns itself closely with the reference content type, so the same content guidelines apply.
 
-## Content of Your Logging Article
+## Content of your logging article
 
-### About the "Description" Section
+### About the "Description" section
 
 The description section gives the reader all the key information they need to understand what the logging entry is and how it is structured.
 
@@ -18,20 +18,20 @@ You don't need to describe the mandatory logging parameters sent by default to t
 
 Only describe the parameters unique to your application or common parameters that are being reused from other applications.
 
-### About the "Logging example" Section
+### About the "Logging example" section
 
 Not having good log file examples can make it hard to debug a problem when you are on-call.
 
 Proper description of the content in a log file can make it easier for the person on-call to solve the problem.
 
-### About the "Log properties" Section
+### About the "Log properties" section
 
 You can specify app-specific log properties in this section.
 
 The biggest tip for writing logging articles is to be as descriptive as possible with each logging parameter.
 Think about why you would want to query this parameter in the logs and what insights or benefits the parameter adds to the log.
 
-## Logging Examples
+## Logging examples
 
 * **Example 1**.
 

--- a/reference/about-reference.md
+++ b/reference/about-reference.md
@@ -1,6 +1,6 @@
-# The Reference Article
+# The reference article
 
-### When Do I Need a Reference Article?
+## When do I need a reference article?
 
 Reference articles provides information-oriented descriptions of specific technology parts.
 
@@ -12,9 +12,9 @@ Reference articles work well when they are:
 * contain descriptive information that is relevant to the reference topic's overview only
 * focus on information accuracy and the facts only.
 
-## Content of Your Reference Article
+## Content of your reference article
 
-### About the "Overview" Section
+### About the "Overview" section
 
 Summarise what the reader will get from reading the reference article.
 
@@ -26,9 +26,9 @@ Creating a good overview comes down to thinking about who is going to be using i
 
 Your overview should be descriptive of the subject you want to cover, so your audience can quickly identify what the reference article is about.
 
-### About the "Body" Section
+### About the "Body" section
 
-There is no specific structure to use in Reference articles because the structure will vary based on the type of factual information you are documenting.
+There is no specific structure to use in reference articles because the structure will vary based on the type of factual information you are documenting.
 
 For example, the example included in the more specific `api-reference` template type in this repository describes how you would structure an API endpoint.
 This reference structure is prescriptive, but only relevant for this documentation type.
@@ -36,9 +36,9 @@ This reference structure is prescriptive, but only relevant for this documentati
 In most cases your content will take on a tabular format of some type.
 It is often easier to present reference style information in a table.
 
-Here are some overall suggestions about how you can structure your Reference articles.
+Here are some overall suggestions about how you can structure your reference articles.
 
-#### Structure Suggestions
+#### Structure suggestions
 
 Follow these suggestions when structuring and writing your reference topics.
 
@@ -47,17 +47,17 @@ Follow these suggestions when structuring and writing your reference topics.
 ** The content is written for the same audience.
 ** The content fits in with your reference document without modification.
 * If you are referring to a screen in a UI:
-** Use a Reference table explaining the fields and their meanings.
+** Use a reference table explaining the fields and their meanings.
 ** Use call-outs in screen shots to help your audience find the field in the reference table.
 
-### Code-generated Documentation
+### Code-generated documentation
 
 Reference articles can often be replaced by _thoroughly-written_ auto-doc output from your code.
 This is particularly the case with content such as API reference docs and package descriptions that are documented in code doc-blocks or are produced with tools such as the Open API toolchain.
 
 If you need to provide more narrative style content to complement your API reference endpoints, see the `api-` template types in this repository.
 
-## How-to Article Examples
+## How-to article examples
 
 * **Example 1**.
 

--- a/reference/template-reference.adoc
+++ b/reference/template-reference.adoc
@@ -21,7 +21,7 @@ Check out https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/ if you g
 
 
 
-.Example Parameter Reference Template
+.Example parameter reference template
 [cols="a,a,a,a" options="header,autowidth"]
 |===
 |Name
@@ -45,11 +45,11 @@ Check out https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/ if you g
 |
 |===
 
-== Field Reference
+== Field reference
 
 image::https://docs.oracle.com/cloud/latest/marketingcs_gs/OMCAA/Resources/Images/Forms/kbf2.x1.jpg[Tux,250,350]
 
-.Example Field Name Reference Template
+.Example field name reference template
 [cols="a,a,a,a" options="header,autowidth"]
 |===
 |Name
@@ -76,7 +76,7 @@ image::https://docs.oracle.com/cloud/latest/marketingcs_gs/OMCAA/Resources/Image
 
 image::https://docs.oracle.com/cloud/latest/marketingcs_gs/OMCAA/Resources/Images/Forms/kbf2.x1.jpg[Tux,250,350]
 
-.Example Nested Table
+.Example nested table
 [cols="1,2a"]
 |===
 | Col 1 | Col 2

--- a/tutorial/about-tutorial.md
+++ b/tutorial/about-tutorial.md
@@ -1,4 +1,4 @@
-# The Overview
+# The overview
 
 ## When do I need a tutorial?
 

--- a/tutorial/about-tutorial.md
+++ b/tutorial/about-tutorial.md
@@ -1,6 +1,6 @@
 # The Overview
 
-### When Do I Need a Tutorial?
+## When do I need a tutorial?
 
 Tutorials are learning-oriented lessons that guide you through a series of steps to complete a project.
 
@@ -8,15 +8,15 @@ They are essential to give new users a feeling that they can achieve something q
 
 Tutorial articles can often be confused with how-to articles, but you won't fall into this trap if you remember that tutorials are _learning_-oriented not _problem_-oriented.
 
-## Content of Your Tutorial
+## Content of your tutorial
 
-### Who is This Tutorial For?
+### Who is this tutorial for?
 
 * Are you writing only for end-users? For developers?
 * Are you writing only for people who have a certain problem to solve?
 * Is it intended for a particular industry?
 
-### Body of the Tutorial
+### Body of the tutorial
 
 Tutorial articles work well when they offer the following features:
 
@@ -27,7 +27,7 @@ Tutorial articles work well when they offer the following features:
 * Function on 100% on the platforms you indicate are supported.
 * Exclude distractions that make your audience have to choose a path in the tutorial.
 
-### About the "Goal" Section
+### About the "Goal" section
 
 Summarise the goals of your tutorial in this section.
 
@@ -53,7 +53,7 @@ Make sure you meet the following prerequisites before starting the tutorial step
 
 ```
 
-### About the Part sections
+### About the "Part" sections
 
 There are two ways of structuring each part in your tutorial:
 
@@ -95,7 +95,7 @@ You get a more conversational flow with this tutorial style, however some of the
 
 If you find your tutorial really only has one main procedure, consider using a `how-to` template, which you can find in this template repository.
 
-## Tutorial Examples
+## Tutorial examples
 
 * **Example 1**.
 

--- a/writing-tips.md
+++ b/writing-tips.md
@@ -2,7 +2,7 @@
 
 Follow these writing guidelines when developing content using the templates available in this repository.
 
-## Language and Tone
+## Language and tone
 
 * Use consistent language, spelling, and tone throughout your docs.
 * Describe things as clearly and accurately as possible.
@@ -25,7 +25,7 @@ Here are some recommendations you can use when creating procedural steps:
 * Too many sub-steps could suggest that you need to break out some of these steps into a new step section.
 * Screenshots and images are recommended, particularly if you can include call outs to the specific parts of the screen you are referring to.
 
-## Page Structure
+## Page structure
 
 * Create an outline of the headings you want to include in the document before you start writing.
   * Use the outline to gather your thoughts about the main topics you need to tell your readers.
@@ -33,7 +33,7 @@ Here are some recommendations you can use when creating procedural steps:
 * You may also find that you need to create two articles if the subject starts to branch.
 * Add any links you mention in the body of your discussion topic into the "See also" section. The inline links may get lost in long articles, and scanning for links adds to your audience's cognitive load.
 
-## Titles and Filenames
+## Titles and filenames
 
 * Make the title descriptive of the content contained within the article.
 * Make the title unique within your application space.
@@ -45,7 +45,7 @@ Here are some title examples and their suggested file name structures:
 * Using a toaster
   * `using-a-toaster.md`
   * `using-a-toaster.adoc`
-* Toast a slice of bread.
+* Toast a slice of bread
   * `toast-slice-of-bread.md`
   * `toast-slice-of-bread.adoc`
 


### PR DESCRIPTION
Things changed and errors found:

- Sentence capitalization as per #47. See [this](https://developers.google.com/style/capitalization#capitalization-in-titles-and-headings).
- Minor changes in extraneous spaces in some documents(these were flagged by my markdown editor and were easy to fix).
- Some documents don't follow the [heading hierarchy](https://developers.google.com/style/headings#formatting-a-heading-or-title) rule. In some documents where the change was obvious(for example third-level heading follows the first-level heading, I made the change). In [about-quickstart.md](https://github.com/thegooddocsproject/templates/blob/master/api-quickstart/about-quickstart.md) I was not sure whether to change the structure(make `What is a quickstart` into a first-level heading) or add an overall heading(something like `About quickstart`. I could use some help.
- Fixed: Absence of a blank line after a title in some places.
- Error - inconsistent use of punctuation for headings which are questions. I've opened an issue for this: #128. Some titles don't use a question mark and some do.
- Also dropped periods in some titles as per [this](https://developers.google.com/style/periods#periods_with_headings)
- For capitalization involving titles with quotations, I assumed the text under quotes to be another title and applied the sentence case rule. For example, Blah "Blah Blah" was changed to Blah "Blah blah". I've checked how the style guide does this. Although not explicitly mentioned, I found one or two cases which follow this although it was done when the quotes were used in a paragraph. Something like this: `See also "Blah blah title"` at the end of a paragraph.

@jaredmorgs please review. I just noticed that there was another issue opened by you for sentence case in #35. But I referenced this in #47 as well.