### PR TITLE
feat(pr-template): initial work on template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,25 +1,25 @@
-> __ALL Pull-Requests require an associated [Issue](https://github.com/thegooddocsproject/templates/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc) as documented in our [Contributing Guide](https://github.com/thegooddocsproject/templates/blob/master/contribute.md#contributing).__
+> __ALL Pull-Requests require an associated [Issue](https://github.com/thegooddocsproject/templates/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc) as documented in [How to contribute](https://github.com/thegooddocsproject/templates/blob/master/contribute.md#contributing).__
 
-## Purpose / Why
+## Purpose / why
 
-> _**Replace This Text** - Restate the purpose/jusitifcation of this work and include links to the Issue inside of the purpose/why._
+> _**Replace this text** - Restate the purpose/justification of this work and include links to the Issue inside of the purpose/why._
 
-## What Changes Were Made?
+## What changes were made?
 
-> _**Replace This Text** - State clearly the direct additions or modifications made in this change-request._
+> _**Replace this text** - State clearly the direct additions or modifications made in this change-request._
 
 ## Verification
 
-> _**Replace This Text** - Document the details that help a reviewer understand what steps or actions should be taken in-order to verify the work is completed and satisfies the initial scope of work._
+> _**Replace this text** - Document the details that help a reviewer understand what steps or actions should be taken in-order to verify the work is completed and satisfies the initial scope of work._
 
 ---
 
 ## Checklist
 
-> __Pull-Request Reviewer__ should ensure the following
+> __Pull-request reviewer__ should ensure the following
 
 * [ ] Are issues linked correctly?
 * [ ] Is this PR labeled correctly?
-* [ ] If, template updates do they align with [developers.google.com/style/](https://developers.google.com/style/)?
+* [ ] If template updates: do they align with [developers.google.com/style/](https://developers.google.com/style/)?
 * [ ] Did the PR receive at least one :+1: and no :-1: from core-maintainers?
-* [ ] On Merging PR, did you complete the merge using [keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-to-an-issue)?
+* [ ] On merging, did you complete the merge using [keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-to-an-issue)?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,21 +14,12 @@
 
 ---
 
-## Type of Change
-
-> __Pull-Request Opener__ should select one of the following
-
-* [ ] __Template Updates__ - _style_, _grammar_, _content_
-* [ ] __Template Structuring__ - _moving template files and or folders_
-* [ ] __Tooling & Support__ - _updates to the repository tooling_
-
----
-
 ## Checklist
 
 > __Pull-Request Reviewer__ should ensure the following
 
-* [ ] Are Issues Linked Correctly?
-* [ ] If, template updates do they align with [Google StyleGuide]()?
-* [ ] Did the PR receive :+1: from core-maintainers?
+* [ ] Are issues linked correctly?
+* [ ] Is this PR labeled correctly?
+* [ ] If, template updates do they align with [developers.google.com/style/](https://developers.google.com/style/)?
+* [ ] Did the PR receive at least one :+1: and no :-1: from core-maintainers?
 * [ ] On Merging PR, did you complete the merge using [keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-to-an-issue)?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+> __ALL Pull-Requests require an associated [Issue](https://github.com/thegooddocsproject/templates/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc) as documented in our [Contributing Guide](https://github.com/thegooddocsproject/templates/blob/master/contribute.md#contributing).__
+
+## Purpose / Why
+
+> _**Replace This Text** - Restate the purpose/jusitifcation of this work and include links to the Issue inside of the purpose/why._
+
+## What Changes Were Made?
+
+> _**Replace This Text** - State clearly the direct additions or modifications made in this change-request._
+
+## Verification
+
+> _**Replace This Text** - Document the details that help a reviewer understand what steps or actions should be taken in-order to verify the work is completed and satisfies the initial scope of work._
+
+---
+
+## Type of Change
+
+> __Pull-Request Opener__ should select one of the following
+
+* [ ] __Template Updates__ - _style_, _grammar_, _content_
+* [ ] __Template Structuring__ - _moving template files and or folders_
+* [ ] __Tooling & Support__ - _updates to the repository tooling_
+
+---
+
+## Checklist
+
+> __Pull-Request Reviewer__ should ensure the following
+
+* [ ] Are Issues Linked Correctly?
+* [ ] If, template updates do they align with [Google StyleGuide]()?
+* [ ] Did the PR receive :+1: from core-maintainers?
+* [ ] On Merging PR, did you complete the merge using [keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-to-an-issue)?


### PR DESCRIPTION
## Purpose

Adding our initial PR Template so that we can improve our process for managing change-requests.  Refers to issue #122 

## What changes were made?

Created the `.githhub/` folder and generated the corresponding `PULL_REQUEST_TEMPLATE.md` file and placed the template into the folder.

## Verification

To [view the RAW Version of the Template](https://github.com/thegooddocsproject/templates/blob/morgan-pr-template-initial/.github/PULL_REQUEST_TEMPLATE.md)

### The Default Look When PR Opened/Drafting

_Quick Visual_ of the default look of the PR Template inside of the PR Panel when __opened/draft-mode__.

![2020-06-15 08 15 51](https://user-images.githubusercontent.com/89339/84656410-a3121500-aee0-11ea-8cb0-47d474d64f52.gif)

### What the Process Looks Like to Fill-Out

_Quick Visual_ of what it looks like to fill it out, once merged it will auto-populate.


![2020-06-15 08 07 41](https://user-images.githubusercontent.com/89339/84655852-b4a6ed00-aedf-11ea-9afc-10070ee60d1f.gif)

---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [x] Are issues linked correctly?
* [ ] Is this PR labeled correctly?
* [ ] If template updates: do they align with [developers.google.com/style/](https://developers.google.com/style/)?
* [ ] Did the PR receive at least one :+1: and no :-1: from core-maintainers?
* [ ] On merging, did you complete the merge using [keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-to-an-issue)?

