### PR TITLE
Add release notes to PR reviewer checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,3 +23,4 @@
 * [ ] If template updates: do they align with [developers.google.com/style/](https://developers.google.com/style/)?
 * [ ] Did the PR receive at least one :+1: and no :-1: from core-maintainers?
 * [ ] On merging, did you complete the merge using [keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-to-an-issue)?
+* [ ] On merging, did you add any applicable notes to a [draft release](https://github.com/thegooddocsproject/templates/releases) and link to this PR?


### PR DESCRIPTION
## Purpose / why

We want to make releasing less painful. To do that, we should update a draft release as we go.

I didn't create an issue because we had already discussed it on a recent call and it's a rather small change. I can open one, if desired.

## What changes were made?

I added one checklist item to the PR template.

## Verification

This feels sort of self-explanatory, but please correct me if I'm wrong.

---

## Checklist

> __Pull-request reviewer__ should ensure the following

* [ ] Are issues linked correctly?
* [ ] Is this PR labeled correctly?
* [ ] If template updates: do they align with [developers.google.com/style/](https://developers.google.com/style/)?
* [ ] Did the PR receive at least one :+1: and no :-1: from core-maintainers?
* [ ] On merging, did you complete the merge using [keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-to-an-issue)?
