### PR TITLE
Add contributing guide and related docs to main branch, see RFC-005

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,345 @@
+# Good Docs Project - Template contributing guide
+
+Welcome to the Good Docs Project!
+If you’re reading this guide, that probably means you’d like to get involved and start contributing to the project.
+This document should hopefully help you become a full templateer (which is how we refer to the members of our community).
+
+One of the core missions of the Good Docs Project is to provide high-quality documentation templates to open source software projects and beyond. However, we also engage in many other similar initiatives around docs advocacy, docs education, and docs tooling.
+We value all contributions to the Good Docs Project initiatives, including templates and our other initiatives. The Join the community section of this guide explains how to get involved in those other related initiatives and provides links for more information.
+
+## Table of contents
+
+- [Before you start](#before-you-start)
+  - [Template roles and resources](#template-roles-and-resources)
+  - [Required deliverables](#required-deliverables)
+- [Overview of the template writing phases](#overview-of-the-template-writing-phases)
+- [Join the community](#join-the-community)
+- [Adopt a template](#adopt-a-template)
+  - [Guidelines for choosing a template](#guidelines-for-choosing-a-template)
+- [Research and draft the template](#research-and-draft-the-template)
+  - [Recommended research strategies](#recommended-research-strategies)
+- [Get feedback on drafts from the community](#get-feedback-on-drafts-from-the-community)
+  - [Accepting feedback from others](#accepting-feedback-from-others)
+- [Submit a pull request](#submit-a-pull-request)
+- [Improve the template with user feedback](#improve-the-template-with-user-feedback)
+
+## Before you start
+
+Before starting, ensure you are familiar with the Good Docs Project’s goals, key concepts, and workflows.
+It might also possibly help to learn more about our project's personas.
+For more information, see [About the Good Docs Project](https://thegooddocsproject.dev/about/).
+
+
+### Template roles and resources
+
+As you work on contributing templates to our project, various resources and members of our community are available to help you along the process. These include:
+
+- **Templateers** - Any individual who contributes to the Good Docs Project (including you!).
+- **The templates coordinator** - This templateer oversees our overall template development process as a project manager and provides assistance to contributors working on templates.
+- **Template mentors** - This group of experienced templateers lead template writing working groups where you can receive guidance and mentorship while working on your template.
+- **Community reviewers** - This group of templateers are available to review templates during the community feedback phase. They include members of your template writing working group but also members from the larger Good Docs Project community who have volunteered to help review templates.
+- **Pull request reviewers** - This group of experienced templateers review and approve pull requests submitted to the templates repository.
+
+In addition to these roles, these resources are available to help you as you contribute templates to our project:
+
+- **Template writing working groups** - Our project is organized into several working groups that meet on a regular basis to work on the project’s key initiatives. To effectively contribute templates to a project, all template writers are required to join one of the template writing working groups, at least if it is your first time contributing.
+- **Templates issue list** - All the templates that are actively being worked on or which could be worked on have a corresponding issue in the templates repository. Use the issue list or the kanban board to find a template to work on and track your template’s progress as it moves throughout the template writing phases.
+
+These roles and resources (including the names of the individuals currently serving in these roles) are explained in the [Template Roles and Resources](template-roles-and-resources.md) guide.
+
+
+### Required deliverables
+
+Currently, for a template set to be considered complete, each template set should have these documentation deliverables:
+
+<table>
+  <tr>
+    <th>Deliverable</th>
+    <th>Description and purpose</th>
+    <th>Required?</th>
+  </tr>
+  <tr>
+    <td>Template file</td>
+    <td>The template file is the raw template for the type of document you are creating. It provides a rough outline of the suggested content and a few embedded writing tips for how to fill in the different sections of the template.</td>
+    <td>Required</td>
+  </tr>
+  <tr>
+    <td>Template guide</td>
+    <td>This guide provides a deeper explanation of how to fill in the template. It provides a lightweight introduction to the purpose of this documentation and explains how to fill in each section of the document. Any information that is essential to filling out the template should be noted in this guide.</td>
+    <td>Required</td>
+  </tr>
+  <tr>
+    <td>Deep dive</td>
+    <td>This optional guide is a supplementary guide that can provide additional helpful information to template users such as key research, deeper theories, brainstorming, or pre-writing steps that are too comprehensive or lengthy to be included in the template guide. What is included in this guide may be unique to each template.</td>
+    <td>Optional</td>
+  </tr>
+  <tr>
+    <td>Template example</td>
+    <td>The Good Docs Project is in the process of designing a fake documentation project that can provide examples of our templates in action. Until this project is ready, it is optional to provide an example of the template. However, if you want to create a fake example as part of your template set, you may do so.</td>
+    <td>Optional</td>
+  </tr>
+</table>
+
+For more detailed information about each deliverable, see [Template Deliverables](template-deliverables.md).
+
+
+## Overview of the template writing phases
+Contributing a template project to our repository has five phases, as summarized in this table:
+
+<table>
+  <tr>
+    <th>Phase</th>
+    <th>Your goals</th>
+    <th>Resources to help you</th>
+  </tr>
+  <tr>
+    <td>1 - Join the community</td>
+    <td><ul>
+          <li>Join our project’s communication channels.</li>
+          <li>Decide which initiative you’d like to work on based on your interests and experience.</li>
+        </ul>
+    </td>
+    <td><ul>
+          <li>The Good Docs Project welcoming committee</li>
+          <li>Working groups</li>
+        </ul>
+    </td>
+  </tr>
+  <tr>
+    <td>2 - Adopt a template</td>
+    <td><ul>
+          <li>Join a template writing working group led by a template mentor.</li>
+          <li>Work with a template mentor and your working group to decide which template you’ll work on.</li>
+          <li>Assign yourself to the corresponding issue for that template.</li>
+        </ul>
+    </td>
+    <td><ul>
+          <li>The issues board on the templates repo</li>
+          <li>Template mentors</li>
+          <li>Templates coordinator</li>
+          <li>Template working groups</li>
+        </ul>
+    </td>
+  </tr>
+  <tr>
+    <td>3 - Research and draft</td>
+    <td><ul>
+          <li>Research examples and best practices for the type of template you are working on.</li>
+          <li>Collaborate and get early feedback on your research from your template mentor and/or other templateers as part of a template writing working group.</li>
+          <li>Create drafts of the template set deliverables in Google Docs or your preferred tool.</li>
+        </ul>
+    </td>
+    <td><ul>
+          <li>Working groups</li>
+          <li>Template mentors</li>
+          <li>Templates coordinator</li>
+        </ul>
+    </td>
+  </tr>
+  <tr>
+    <td>4 - Get feedback on drafts from the community</td>
+    <td><ul>
+          <li>Revise and refine the drafts of your deliverables. Expect to receive feedback from at least three community reviewers. Community reviewers are anyone who is a member of the Good Docs Project, including members of template writing working groups.</li>
+
+          <li>Optional: Revise and refine your draft with individuals beyond our community (such as Write the Docs or subject matter experts).</li>
+          <li>After making revisions, work with your template mentor and the templates coordinator to determine when your draft is ready for the next phase.</li>
+        </ul>
+    </td>
+    <td><ul>
+          <li>Community reviewers</li>
+          <li>Subject matter experts and members of other technical writing communities</li>
+          <li>Template mentors</li>
+          <li>Templates coordinator</li>
+        </ul>
+    </td>
+  </tr>
+  <tr>
+    <td>5 - Submit a pull request</td>
+    <td><ul>
+          <li>If needed, convert drafts from Google Docs or your preferred tool to Markdown.</li>
+          <li>Open a pull request. NOTE: If you are unfamiliar with Git and GitHub, your template mentor or another community member can help you.</li>
+          <li>Revise documents based on requests from pull request reviewers.</li>
+        </ul>
+    </td>
+    <td><ul>
+          <li>Pull request reviewers</li>
+          <li>Template mentors</li>
+          <li>Templates coordinator</li>
+        </ul>
+    </td>
+  </tr>
+  <tr>
+    <td>6 - Improve the template with user feedback</td>
+    <td><ul>
+          <li>After completing the previous phase, your template will officially be part of the Good Docs Project and will be available to our users.</li>
+          <li>As users try your template out in the wild, they may report usability issues or provide feedback for improvements to the template.</li>
+          <li>Either the original template author or another templateer will evaluate feedback and incorporate it into future versions of the template. When that happens, the template will go through the same previous phases again.</li>
+        </ul>
+    </td>
+    <td><ul>
+          <li>Template mentor</li>
+          <li>Templates coordinator</li>
+        </ul>
+    </td>
+  </tr>
+</table>
+
+Each phase is explained in more depth in the remaining sections.
+
+
+## Join the community
+
+To become a full-fledged templateer, you’ll want to join our communication channels so that you can talk to us:
+
+- **Slack** - Our [Slack workspace](https://thegooddocs.slack.com/) is one of the primary means of communicating with members of our project. After joining our workspace, join the `#welcome` channel to introduce yourself to the welcoming committee. Consider also joining these Slack channels if you plan to work on a template:
+  - `#templates`
+  - `#community-docs`
+  - `#welcome`
+  - `#topical`
+- **Group forums** - Join our [Groups.io mailing list](https://thegooddocsproject.groups.io/g/main/topics) to communicate with other templateers over email. These messages can be grouped into a daily digest for your convenience.
+- **Working groups** - Our project is organized into several different working groups that meet on a regular basis to work on the project’s key initiatives. One of the best ways to get started with our project is to join and meet with one of our working groups. See [The Good Docs Project Working Groups](https://thegooddocsproject.dev/working-group/) for a list of our current active groups. NOTE: If you plan to contribute to our project by writing templates, you will be required to join one of the template-focused working groups.
+- **Weekly meetings** - The project leaders hold two weekly meetings to discuss project-level decisions. Feel free to join one of these meetings to introduce yourself to the project leaders and discover next steps for getting involved in the project. We currently hold meetings for the U.S./Canada and APEC/EU/Africa time zones. After introducing yourself on Slack, one of the members of the welcoming committee can help you get invited to the best meeting for your time zone.
+
+As you begin to join our project, remember that this is a project composed entirely of volunteers.
+We love to welcome new members, but want to be careful not to burn out our core project contributors.
+This level of mindfulness helps us ensure that we retain our project’s capacity to produce high-quality work.
+As such, we ask that you respect the time of our project maintainers and contributors.
+(And expect us to respect your time in return!)
+
+We expect all members of our project to be nice to each other and to follow our [Code of Conduct](https://thegooddocsproject.dev/code-of-conduct/) when interacting with other members of the Good Docs Project.
+
+
+## Adopt a template
+
+In this phase, you will decide which template project you will work on and adopt that template.
+
+Be aware that:
+- Each template project is represented by a corresponding issue in the [Good Docs Project templates](https://github.com/thegooddocsproject/templates/issues) repository.
+- You will use this issue to communicate the status of your template project as it moves through the different phases of the template writing process.
+- The Good Docs Project managers use a kanban board that shows all the issues for the current template projects. This tool allows the templates coordinator, template mentors, community reviewers, and other stakeholders to track the overall progress of each template and assist templateers whose progress is blocked.
+
+To adopt a template:
+
+1. Scroll through the list of template issues and see if one interests you and/or matches your skill set. Alternatively, if you have an idea for a template project that does not yet have an issue, and you have the support of a template mentor, you can create a new issue for your template project.
+
+2. Assign yourself to the issue. See [Assigning issues and pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users) in the GitHub docs for more information.
+
+3. Notify the current templates coordinator that you have adopted a template project. To notify the templates coordinator, ideally send them a direct message on Slack or tag them in the issue. Alternatively, you could tell your template mentor (the leader of your template working group) and they will ensure the templates coordinator is notified.
+
+If you claim a template and later realize that you don’t have the time or energy to complete the template project, please let the templates coordinator or your template mentor know.
+
+
+### Guidelines for choosing a template
+
+Keep in mind that you don’t need to be an expert on any template type before you adopt it.
+If you are interested in writing a particular template and are excited enough to do some research to learn more about it, that's all the preparation you need and we welcome your efforts.
+Even if you don't have a ton of experience writing a particular type of document, you can still write a high-quality template that will be useful to others.
+With commitment, research, guided mentorship, and feedback from our community, you can and will create something that will have value to others!
+
+With that in mind, when deciding which template project is right for you, scroll through the list of template issues and ask yourself the following questions:
+
+- Does something about this type of document or template intrigue you, spark your curiosity, and make you excited to research and learn more?
+- Do you wish you knew how to create the best version of this type of document? Are you energized by the idea of researching best practices or gleaning insights from subject matter experts about this type of document?
+- Do you have experience writing for this type of document which you would like to share?
+Would having a high quality version of this type of template make your life easier at your workplace or for your open source project?
+- Do you feel like there is a strong need for improved versions of this type of document in the world? Do you see lots of bad examples of this document that frustrate you?
+- Has the Good Docs Project labeled this type of template as a high priority for our project? (Keep in mind that you can work on any template that you feel enthusiastic about, regardless of priority. That being said, we welcome work on our high priority templates.)
+
+If you answered yes to more than one of these questions about a specific type of template, that might be the right template for you to work on!
+
+
+## Research and draft the template
+
+In this phase, you will research examples and identify best practices for the type of template you’re working on.
+At the end of this stage, our project recommends producing your working draft of the template project deliverables in a Google Doc. The reasons we recommend putting your draft in a Google Doc are because it:
+
+- Is free (no license required) and easy to use.
+- Is relatively easy to share with collaborators both inside and outside of the Good Docs project (such as with the Write the Docs community).
+- Allows collaborators to give feedback and advice in the form of comments.
+- Tracks comment history for later reference.
+- Has version control capabilities.
+
+That being said, you are not required to work in Google Docs. You can work in your preferred tool (such as Markdown, Microsoft Word, or Gitbooks). However, our experience has shown that Google Docs is the easiest tool for collaborating with other Good Docs Project contributors in the early phases of doc development.
+
+### Recommended research strategies
+
+In our experience, successful templateers usually research their template by:
+
+- **Looking at lots of examples.** Start by searching for examples of that type of document they want to create a template for. The more examples you can look at, the better. While it’s better to review good examples of that type of document, there is actually a lot of value in reviewing bad examples too. Consider keeping a spreadsheet to track which examples you used, what elements each one had in common, and what you thought was effective or ineffective.
+- **Searching for guides, books, blog posts, conference presentations, or videos about best practices.** Search the Internet to find advice, tips, or expert research about how to create that type of document. Consider posting in a forum for resource ideas. For example, asking for helpful guides or insights on a community forum like the Write the Docs Slack workspace could be beneficial. Be mindful of, and respect copyright terms of source material. Do not plagiarize and offer attribution where appropriate.
+- **Reaching out to experts.** When you find people you admire, who have researched your topic already, try reaching out to them. They often have a “how to contact me” webpage. Ask if they’d be okay with their material being used. (They might need to republish under a different copyright.) Invite them to participate in the template working group. They might even be prepared to lead it. If you feel shy about reaching out yourself, your template mentor or senior Good Docs Project member might offer to help.
+- **Collaborating with others in a working group.** Work with your template writing working groups to discuss research ideas and findings.
+
+
+## Get feedback on drafts from the community
+
+In this phase, you’ll begin to share your drafts with community reviewers and invite feedback.
+Optionally, you might also consider sharing it beyond our community with other technical writing communities such as Write the Docs or beyond.
+The feedback and revision phase is arguably the most crucial and important phase in the template writing process, so your template project might spend the bulk of its time in this phase.
+
+To share your Google Docs drafts:
+
+1. Inside the draft, click the **Share** button and change the **Get Link** settings to: **Anyone on the internet with this link can create comments.**
+
+2. Copy the link to your Google Doc drafts into the issue that corresponds with your template in the templates repository.
+
+3. Notify the templates coordinator or your template mentor, who will help you get reviews for your draft from the community reviewers group.
+
+The templates coordinator will help you find reviewers. Typically three or more community reviewers will provide a detailed review of your material. When you’ve received sufficient community input and incorporated suggestions into your draft, you will collaborate with a templates coordinator to determine that your draft is ready to move to the next phase.
+
+> :triangular_flag_on_post: **NOTE: You can only move to the next phase (submitting a pull request) after the templates coordinator or your template mentor has approved your draft to move on.**
+
+
+### Accepting feedback from others
+
+It’s normal to feel nervous about sharing your drafts, especially if you’re a new writer or if you don’t feel as confident in your subject matter knowledge yet.
+But your draft can only become the best template it can be if you invite and incorporate high quality feedback into your drafts.
+Successfully accepting advice on a draft is a key element that distinguishes expert writers from novice writers.
+
+Sharing your work with reviewers:
+
+- Allows you to see your draft with fresh eyes the way a new user would see it.
+- Can make you aware of key insights or perspectives that you hadn’t yet considered.
+- Can help you identify which parts of your draft need more careful thought, attention, and revision.
+
+As you receive feedback, try to give each comment the benefit of the doubt and seriously consider it.
+Sometimes new writers are tempted to react defensively to feedback on their work, but remember that your reviewers have the same goals that you have: to produce a high quality template!
+But also keep in mind that you don’t need to accept every suggestion.
+If you can make a good argument not to adopt a suggestion, that is important to consider as well.
+
+One other thing that might help you get more high quality reviews is to clearly indicate what kind of feedback you’re looking for, based on areas of the draft you think need some improvement. Do you need:
+
+- Global-level feedback, which includes advice on the big picture, general content, tone, clarity, and overall organization or flow of the document?
+- Local-level feedback, which includes wordsmithing paragraphs or sentences and polishing up the draft for final revision?
+
+Remember to be positive and show appreciation when people take time to review your drafts.
+Providing feedback takes time and energy.
+Treat each piece of feedback as a gift (even feedback that you possibly choose to disregard).
+Happy editing!
+
+
+## Submit a pull request
+
+The purpose of this phase is to ensure your template project meets the standards of the Good Docs Project and is ready for public distribution.
+In this phase, you’ll convert your template documents into Markdown and open a pull request in the `templates` repository on GitHub.
+
+If you are not comfortable working in Markdown, Git, or GitHub, a community member (such as your template mentor) will assist you.
+
+Once you’ve submitted a pull request, the templates coordinator will assign at least two members from the approved pull request reviewer list to review your template.
+These reviewers will check the template to ensure it meets the project’s formatting and quality guidelines as outlined in our template pull request checklist.
+This review is intended to be a final quality check to determine whether the template is ready to be officially included in the Good Docs Project.
+Once the template has two approvals, it can be merged into the final project by a templates coordinator or a template mentor.
+
+
+## Improve the template with user feedback
+
+After you’ve submitted your pull request in the previous phase, your template will officially be part of the Good Docs Project. Yay!
+
+:sparkles: :mega: :raised_hands:
+
+However, great documents are never fully done and there is always room for improvement.
+As users try your template in their own documentation projects, they may report usability issues or provide feedback for improvements to the template.
+If our project receives this feedback and you’re still around to work on your original template, we encourage you to carefully review this feedback and incorporate these revisions into future versions.
+If you are not around to continue working on your original template or if you are too busy, we can find a different templateer to respond to user feedback on your behalf.
+
+If a templateer determines that a new version of a template is warranted, they will take the template through the same contributing process starting from the beginning.

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,105 @@
+# Template quality checklist
+
+This quality checklist will eventually become a pull request template that every contributor needs to add to pull requests against the `templates` repository.
+
+
+# Pull request summary
+
+{Describe the purpose of your pull request.}
+
+{Also indicate which template working group you belong to and who your template mentor is.}
+
+## Template contributor checklist
+
+IMPORTANT: The next three sections in this checklist should be filled out by the template contributor at the time they submit this request.
+
+NOTE: Pull requests can only be merged when all boxes are checked.
+
+### Which issue does this pull request fix or reference?
+
+This pull request:
+
+- Resolves: {Choose this option if this PR will close the issue and link to issue}
+- Relates to: {Choose this option if this PR only references an issue for context but does not fully resolve it}
+
+### Procedural requirements
+
+- [ ] The template contributor participated in a template working group to create this template.
+- [ ] This template was submitted to the community for feedback.
+- [ ] A template mentor approved this template set to move to the pull request phase.
+
+
+### Template set requirements
+
+- [ ] Template file is present.
+- [ ] Template guide is present.
+- [ ] Template deep dive is present (optional).
+- [ ] Template example is present (optional).
+- [ ] If the optional template example is not present, open a new issue was created to track this task (include link).
+
+
+## Template pull request reviewer checklist
+
+IMPORTANT: The rest of the sections in this checklist should only be filled out by authorized Good Docs Project pull request reviewers. If you are the individual template contributor, do not fill out the rest of the fields or check the boxes.
+
+NOTE: Pull requests can only be merged when all boxes are checked.
+
+
+### Mechanics and formatting requirements - PULL REQUEST REVIEWER ONLY
+
+- [ ] Check rendered Markdown output to ensure it renders correctly.
+- [ ] Review the template set to ensure all documents follow the template markdown style guide.
+- [ ] The template set is free from grammar errors and typos.
+
+
+### Overall usability - PULL REQUEST REVIEWER ONLY
+
+- [ ] The scope of the template set is appropriate, meaning it is not too simple or overly complex (i.e. it needs to be expanded or broken into multiple smaller templates).
+- [ ] The template is complete and comphrehensive.
+- [ ] The template set is well-organized and the contents flow in a logical order.
+- [ ] The template is well-written and clear.
+- [ ] The template set provides sufficient guidance about how to fill it in and implement the template in a documentation project.
+
+
+### Template file requirements - PULL REQUEST REVIEWER ONLY
+
+- [ ] Check rendered Markdown output to ensure it renders correctly and follows the template markdown style guide.
+- [ ] The template title is present and is an H1.
+- [ ] The template includes an introductory comment mentioning the other template resources (such as the guide).
+- [ ] Embedded writing tips are formatted with {curly brackets}.
+- [ ] The template is free from grammar errors and typos.
+- [ ] The scope of the template is appropriate, meaning it is not too simple or overly complex (i.e. it needs to be expanded or broken into multiple smaller templates).
+- [ ] The template is complete and comphrehensive.
+- [ ] The template is well-organized and the contents flow in a logical order.
+- [ ] The template is well-written and clear.
+
+
+### Template guide requirements - PULL REQUEST REVIEWER ONLY
+
+- [ ] Check rendered Markdown output to ensure it renders correctly and follows the template markdown style guide.
+- [ ] The template guide title is present and is an H1.
+- [ ] The template includes an introductory comment pointing them to other template resources.
+- [ ] Embedded writing tips are formatted with {curly brackets}.
+- [ ] The template guide is free from grammar errors and typos.
+- [ ] The template guide includes a "Why do I need this type of document?" section.
+- [ ] The template guide includes a "Contents of this template" section.
+- [ ] The contents listed in the "Contents of this template" section mirror the sections in the raw template.
+- [ ] The template guide includes an implementation checklist (optional).
+- [ ] The template guide includes additional resources (optional).
+- [ ] The template guide is well-organized and the contents flow in a logical order.
+- [ ] The template guide is well-written, clear, and provides sound advice to template users.
+
+
+### Deep dive requirements (optional) - PULL REQUEST REVIEWER ONLY
+
+- [ ] Check rendered Markdown output to ensure it renders correctly and follows the template markdown style guide.
+- [ ] The deep drive title is present and is an H1.
+- [ ] The deep dive guide provides helpful advice about necessary requirements for writing this type of documentation.
+- [ ] The template set is well-organized and the contents flow in a logical order.
+- [ ] The template is well-written and clear.
+
+
+### Template example requirements (optional) - PULL REQUEST REVIEWER ONLY
+
+- [ ] Check rendered Markdown output to ensure it renders correctly and follows the template markdown style guide.
+- [ ] The template example provided is well-written and provides a clear example of how to use the template.

--- a/template-deliverables.md
+++ b/template-deliverables.md
@@ -1,0 +1,156 @@
+# Template deliverables
+
+This document explains the different documentation deliverables that template authors are required to write as part of each template set. First, read our Template Contributing Guide to understand the larger context for these deliverables.
+
+## Table of contents
+
+- [Overview](#overview)
+- [Template file](#template-file)
+- [Template guide](#template-guide)
+- [Deep dive (optional)](#deep-dive-optional)
+- [Template example (optional)](#template-example-optional)
+
+
+## Overview
+
+Each template set should have the following components:
+
+<table>
+  <tr>
+    <th>Deliverable</th>
+    <th>Description and purpose</th>
+    <th>Required?</th>
+  </tr>
+  <tr>
+    <td>Template file</td>
+    <td>The template file is the raw template for the type of document you are creating. It provides a rough outline of the suggested content and a few embedded writing tips for how to fill in the different sections of the template.</td>
+    <td>Required</td>
+  </tr>
+  <tr>
+    <td>Template guide</td>
+    <td>This guide provides a deeper explanation of how to fill in the template. It provides a lightweight introduction to the purpose of this documentation and explains how to fill in each section of the document. Any information that is essential to filling out the template should be noted in this guide.</td>
+    <td>Required</td>
+  </tr>
+  <tr>
+    <td>Deep dive</td>
+    <td>This optional guide is a supplementary guide that can provide additional helpful information to template users such as key research, deeper theories, brainstorming, or pre-writing steps that are too comprehensive or lengthy to be included in the template guide. What is included in this guide may be unique to each template.</td>
+    <td>Optional</td>
+  </tr>
+  <tr>
+    <td>Template example</td>
+    <td>The Good Docs Project is in the process of designing a fake documentation project that can provide examples of our templates in action. Until this project is ready, it is optional to provide an example of the template. However, if you want to create a fake example as part of your template set, you may do so.</td>
+    <td>Optional</td>
+  </tr>
+</table>
+
+Each template deliverable is explained in the following sections.
+
+## Template file
+
+Example filename: abc-template.md
+
+The template file is the basic template for the type of document you are creating.
+It provides a rough outline of the suggested content and a few embedded writing tips for how to fill in the different sections of the template.
+The template user will copy this template and begin filling it in or editing it as their starting point in the writing process.
+
+### Content and formatting guidelines
+
+Each template should have this content:
+- **The template title** - The type of document this template is for. For example, "Tutorial template" or "README template."" This title should be formatted with the heading 1 weight.
+- **Introductory comment** - Include an embedded writing tip at the start that tells users they should first read the accompanying template guide and before-you-start guide before they fill in the template. Put introductory comments in {curly brackets}.
+- **The template sections** - Each section of the temple should begin with a heading with the heading 2 weight. The recommended content and some embedded writing tips fall under the headings.
+- **Embedded writing tips** - You can provide some lightweight writing tips that provide some tips or hints about what kind of content the template user might choose to put in a section of the document. Put embedded writing tips in {curly brackets}.
+
+> :triangular_flag_on_post: **NOTE: The basic content of the template depends on the type of document you are creating a template for. Different types of documents can have widely varying content needs. While similar document types are likely to require similar structures, other document types may be structured quite differently.**
+
+
+### Frequently asked questions
+
+**Q: Is it better to include all the possible sections that someone could possibly include in the template file or should it just have the most common sections?**
+
+A: While this is mostly a judgment call on your part as the template author, it might be better to err on the side of being comprehensive.
+Don’t forget that in your template guide you can indicate whether it is common or recommended to include this section or not.
+
+**Q: Can I use heading 3 weights for sub-sections?**
+
+A: Yes, but try not to go much deeper than level 3.
+
+
+## Template guide
+
+Example filename: abc-template-guide.md
+
+This guide provides a deeper explanation of how to fill in the template.
+It provides a lightweight introduction to the purpose of this documentation and explains how to fill in each section of the document.
+
+This guide explains the key decisions that the template user needs to make during the writing process.
+
+This guide might also optionally include a checklist of the required components for this type of document.
+It might also include a list of helpful resources or examples that were consulted when the template was created.
+
+
+### Content and formatting guidelines
+
+The template guide should follow the same basic structure:
+
+- **Template guide title** - The type of document this template is for and the words "guide." For example, "Tutorial guide" or "README guide." This title should be formatted with the heading 1 weight.
+- **Introductory comment** - Include an embedded writing tip at the start that tells users they should first read this guide and the before-you-start guide before they fill in the template. This comment could also mention how to get the template file. Put introductory comments in {curly brackets}.
+- **Why do I need this type of document?** - Provide some of the information about the purpose of this type of document and how it helps your documentation project. The header for this section should be formatted with the heading 2 weight.
+- **Content of this template** - This header marks the beginning of the part of the guide that explains how to fill in each section of the guide. It should be formatted with the heading 2 weight.
+- **About the {insert section name here} section** - Next, include each section as they appear in the template with the heading 3 weight. For example, if your template includes a "Before you start" section, this heading should say "About the before your start section." And then it should provide guidance about what kind of content goes in that section and why that section might be included in the final document. If the section is optional, indicate why some documents could benefit from that section or why it might be left out. If the template user needs to make a decision about the content in that section, provide guidance about what should go into that section.
+- **Checklist (optional)** - If it makes sense to include a checklist of the typical content required for this type of document, include that here.
+- **Additional resources (optional)** - If you’d like to point the user to any helpful guides for deeper study or if you want to acknowledge any resources that inspired you while you wrote this template, link to or cite those resources here.
+- **Optional sections** - If your template could benefit from these sections, you may add them:
+  - User stories
+  - Nature of content
+  - Priorities for each quality criteria
+  - Implementation strategy (e.g. can this doctype be automatically generated from code?)
+  - Business case
+  - When to include? When not to include?
+  - Customization guidelines
+  - Maintenance strategy
+
+
+### Frequently asked questions
+
+Q: No questions yet.
+
+
+## Deep dive (optional)
+
+Example filename: template-abc-deep-dive.md
+
+This optional guide contains miscellaneous information or guidance that is too comprehensive for the "guide" document. Based on whatever the each unique template needs, this document could include research, deep theories, pre-writing information, and/or any other material that users need to know when implementing this topic. Template writers are encouraged to point/link readers to that document in their guide to encourage users to read it in more depth.
+
+If the template's documentation type has certain key decisions that need to be made with stakeholders or if it has a dependency on some other type of document or process, that should be mentioned in the deep dive guide. Template writers are encouraged to point/link readers to the deep dive document in their template guide to encourage users to read it in more depth.
+
+
+### Content and formatting guidelines
+
+Each deep dive should have the following sections:
+
+- **Template title deep dive** - The type of document this template is for + "deep dive". For example, "Tutorial deep dive" or "README deep dive." This title should be formatted with the heading 1 weight.
+- **Research guidance (optional)** - The rest of this guide should contain guidance for researching or pre-writing this document. For example, if you were writing a tutorial template, you might include guidance about how to select a tutorial project that is meaningful, fun, teaches the concepts you need to cover, and is the right size for the reader. Alternatively, you could provide a list of questions the template user should know the answer to before they start writing.
+- **Process or document dependencies (optional)** - Some templates have dependencies on other documents or are dependent on key internal processes that the user needs to create before they can successfully use this template. For example, if the template is for a bug report template, the user needs to think through how their organization will handle bug reports when they receive them.
+- **Any additional content that is unique to your template (optional)** - Whatever you consider necessary to provide to your template users to set them up for success, you can include that information here.
+
+
+### Frequently asked questions
+
+**Q: What if my template is dependent on a type of document that we have a related Good Docs Project template for?**
+
+A: Indicate that dependency in the deep dive document and link to the other template so that users know how to access that template.
+
+**Q: What if my template is dependent on a type of document that we don’t yet have any Good Docs Project templates for?**
+
+A: Create a new issue for that template in the templates repository and indicate that your template is dependent on this content.
+
+
+## Template example (optional)
+
+Example filename: abc-template-example.md
+
+The Good Docs Project is in the process of designing a fake documentation project that can provide examples of our templates in action. Until this project is ready, it is optional to provide an example of the template.
+However, if you want to create a fake example as part of your template set, you may do so.
+
+If you choose not to create a template example, open an issue indicating that this template still needs an example.

--- a/template-roles-and-resources.md
+++ b/template-roles-and-resources.md
@@ -1,0 +1,161 @@
+# Good Docs Project - Template roles and resources
+
+This document explains the template contributor roles and other tools and resources that support the template creation process. See the [Template Contributing Guide](template-contribuing-guide.md) to understand the larger context for these roles and resources.
+
+## Table of contents
+
+- [Template writing working groups](#template-writing-working-groups)
+- [Templates coordinator](#templates-coordinator)
+- [Template mentors](#template-mentors)
+- [Community reviewers](#community-reviewers)
+- [Pull request reviewers](#pull-request-reviewers)
+
+
+## Template writing working groups
+
+Our project is organized into several working groups that meet on a regular basis to work on the project’s key initiatives.
+One of the best ways to get started with our project is to join and meet with one of our working groups.
+See [The Good Docs Project Working Groups](https://thegooddocsproject.dev/working-group/) for a list of our current active groups.
+
+If you are a first-time contributor, you are required to join a template writing working group as you work on your first template project.
+
+The working groups that are specifically devoted to template writing are:
+
+- [Community Docs](https://thegooddocsproject.dev/working-group/community-docs/)
+- [EMEA-APAC Templateers](https://thegooddocsproject.dev/working-group/emea-apac/)
+
+> :triangular_flag_on_post: **NOTE: As a template writing working group grows, it might need to be broken up into smaller groups. When separate groups should be formed will be left to the discretion of the template mentor leading the group, but the general recommendation is no more than 5-6 participants.**
+
+## Templates coordinator
+
+This templateer oversees our overall template development process and provides assistance to contributors working on templates.
+
+The current acting templates coordinator is Aaron Peters.
+
+
+### Responsibilities
+
+The templates coordinator:
+- Acts as a project manager for all template-related work.
+- Oversees the overall template development process and provides assistance to contributors working on templates, such as helping get community reviewers or pull request reviewers to look at template drafts.
+- Coordinates and communicates regularly with the template authors, template mentors, community reviewers, and pull request reviewers.
+- Ensures each template receives at least three community reviews on their draft when a template is in the feedback phase.
+- Acts as a gatekeeper for template quality and, along with a template mentor, makes the final judgment call about when a template is ready to move from the feedback phase to the pull request phase.
+- Is authorized to merge template pull requests.
+- Tracks whether the ticket for that template can be closed or if additional tickets need to be created to reflect dependent tasks.
+
+
+### Eligibility
+
+To become the templates coordinator:
+
+- You should be a member in good standing in the Good Docs Project community, as defined in our [Code of Conduct](https://thegooddocsproject.dev/code-of-conduct/).
+- You should optionally have experience with the template writing process, which is demonstrated by one or more of the following:
+  - Completing a full template set from beginning to end.
+  - Serving as a template mentor for at least 2 months.
+- You must be nominated for this role by the existing templates coordinator, an existing template mentor, or a member of the project steering committee.
+- Receive approval from a majority of members of the project steering committee.
+
+
+## Template mentors
+
+This group of experienced templateers can suggest approaches to challenging template development problems.
+They lead template writing working groups, which often act as workshops where template authors can receive guidance and mentorship while working on templates.
+
+The current template mentors are:
+
+- Aidan Doherty
+- Alyssa Rock
+- Cameron Shorter
+
+
+### Responsibilities
+
+Template mentors:
+- Lead a template writing working group.
+- Mentor other writers and give them the tools, perspectives, and resources to help them create high quality templates.
+- Are very knowledgeable about the template writing policies and procedures and can answer questions that working group members might have about the process.
+- Help connect writers to resources or subject matter experts that can provide feedback on their template drafts.
+- Provide assistance to contributors working on templates in their group, especially when they are blocked.
+- Coordinate and communicate regularly with the templates coordinator.
+- Work with the templates coordinator to ensure each template receives at least three community reviews on their draft when a template is in the community feedback phase.
+- Notify the templates coordinator and make recommendations about when a template is ready to move from the community feedback phase to the pull request phase.
+
+
+### Eligibility
+
+To become a template mentor:
+- You should be a member in good standing in the Good Docs Project community, as defined in our [Code of Conduct](https://thegooddocsproject.dev/code-of-conduct/).
+- You should be an experienced technical writer with good communication and collaboration skills.
+- You should be familiar with strategies for leading effective writer’s workshops.
+- You should have experience with the template writing process, which is demonstrated by one or more of the following:
+  - Completing a full template set from beginning to end.
+  - Participating in a template-focused working group for at least 2 months.
+- You must volunteer and be endorsed for this role by the templates coordinator, a template mentor, or a member of the project steering committee.
+
+
+## Community reviewers
+
+In addition to the members of template writing working groups, this group of volunteer templateers review templates during the community feedback phase.
+
+> :triangular_flag_on_post: **NOTE: At least three community reviews are required for each template, but more are preferred.**
+
+Acting as a community reviewer is a good way for an experienced technical writer to start getting involved with The Good Docs Project and provide a first contribution.
+
+Community reviewers includes anyone who is a member of the Good Docs Project, including members of template writing working groups.
+
+
+### Responsibilities
+
+Community reviewers:
+- Respond to requests from the templates coordinator and/or template mentors when a community member has a draft that needs review.
+- Provide meaningful feedback that will help the template produce a high-quality template.
+- Encourage both global-level revisions (on the document as a whole) and local-level revisions (at the paragraph, sentence, or word level) as needed.
+- Strive to give feedback that is constructive and avoid making comments that will increase defensiveness.
+- Be available (asynchronously) to the templateer if they have follow-up questions or concerns about your feedback.
+
+
+### Eligibility
+
+To become a community reviewer:
+- You should be a member in good standing in the Good Docs Project community, as defined in our [Code of Conduct](https://thegooddocsproject.dev/code-of-conduct/).
+- You should have writing experience or subject matter expertise for the type of document being reviewed.
+- You should be familiar with the [Conventional Comments](https://conventionalcomments.org/) theory of labeling feedback.
+- Let the current templates coordinator or a template mentor know that you want to volunteer as a community reviewer.
+
+
+## Pull request reviewers
+
+This group of experienced templateers review and approve pull requests to the templates repository.
+
+> :triangular_flag_on_post: **NOTE: At least two pull request reviewer approvals are necessary to merge a template into the project.**
+
+The current pull request reviewers are:
+
+- Aidan Doherty
+- Alyssa Rock
+- Cameron Shorter
+
+### Responsibilities
+
+Pull request reviewers:
+- Act as gatekeepers for template quality and assist in making the final judgment call about when a template is ready to merge.
+- Apply the [template quality checklist](template-quality-checklist.md) to each pull request to ensure it meets the project’s standards for quality.
+- Strive to give feedback that is constructive and avoid making comments that will increase defensiveness.
+- Be available (asynchronously) to the templateer if they have follow-up questions or concerns about your feedback.
+- Coordinate and communicate regularly with the templates coordinator.
+- Work with the templates coordinator to ensure each template receives at least two reviews from pull request reviewers when a template is in the pull request phase.
+- Notify the templates coordinator and make recommendations about when a template is ready to be merged.
+
+
+### Eligibility
+
+To become a pull request reviewer:
+- You should be a member in good standing in the Good Docs Project community, as defined in our [Code of Conduct](https://thegooddocsproject.dev/code-of-conduct/).
+- You should be familiar with the Conventional Comments theory of labeling feedback.
+- You should be an experienced technical writer who is familiar with our project’s standards for quality.
+- You should have experience with the template writing process, which is demonstrated by one or more of the following:
+  - Completing a full template set from beginning to end.
+  - Participating in a template writing working group for at least 2 months.
+- You must be nominated for this role by the existing templates coordinator, a template mentor, or a member of the project steering committee.
+- Receive approval from members of the project steering committee.


### PR DESCRIPTION
This PR adds the contributing guide and related documents to the **main** branch, per RFC-005.

NOTE that:

- `template-contributing-guide.md` from RFC-005 is now `CONTRIBUTING.md`
- `template-quality-checklist.md` from RFC-005 is now `pull_request_template.md` (which makes it so that this becomes the default pull request template for PRs in this repo