### PR TITLE
Add links to about pages of current templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Current templates:
 | Template name | Documentation type | Description |
 | ------------- | ------------------ | ----------- |
 | [API Project overview](about-overview.md) | Concept | An overview of your API |
-| [API Quickstart](https://github.com/thegooddocsproject/templates/blob/dev/api-quickstart/about-quickstart.md) | Concept, Task | Simplest possible method of implementing your API |
+| [API Quickstart](api-quickstart/about-quickstart.md) | Concept, Task | Simplest possible method of implementing your API |
 | [API Reference](https://github.com/thegooddocsproject/templates/blob/dev/api-reference/about-api-reference.md) | Reference | List of references related to your API |
 | [Explanation](https://github.com/thegooddocsproject/templates/blob/dev/explanation/about-explanation.md) | Concept | Longer document giving background or context to a topic |
 | [How-to](https://github.com/thegooddocsproject/templates/blob/dev/how-to/about-how-to.md) | Task | A concise set of numbered steps to do one task with the product. |

--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@ Current templates:
 
 | Template name | Documentation type | Description |
 | ------------- | ------------------ | ----------- |
-| API Project overview | Concept | An overview of your API |
-| API Quickstart | Concept, Task | Simplest possible method of implementing your API |
-| API Reference | Reference | List of references related to your API |
-| Explanation | Concept | Longer document giving background or context to a topic |
-| How-to | Task | A concise set of numbered steps to do one task with the product. |
-| Tutorial | Concept, Task | Instructions for setting up an example project using the product, for the purpose of learning. |
-| General reference entry | Reference | Specific details about a particular topic |
-| Logging reference | Reference | Description of log pipelines |
+| [API Project overview](https://github.com/thegooddocsproject/templates/blob/dev/api-overview/about-overview.md) | Concept | An overview of your API |
+| [API Quickstart](https://github.com/thegooddocsproject/templates/blob/dev/api-quickstart/about-quickstart.md) | Concept, Task | Simplest possible method of implementing your API |
+| [API Reference](https://github.com/thegooddocsproject/templates/blob/dev/api-reference/about-api-reference.md) | Reference | List of references related to your API |
+| [Explanation](https://github.com/thegooddocsproject/templates/blob/dev/explanation/about-explanation.md) | Concept | Longer document giving background or context to a topic |
+| [How-to](https://github.com/thegooddocsproject/templates/blob/dev/how-to/about-how-to.md) | Task | A concise set of numbered steps to do one task with the product. |
+| [Tutorial](https://github.com/thegooddocsproject/templates/blob/dev/tutorial/about-tutorial.md) | Concept, Task | Instructions for setting up an example project using the product, for the purpose of learning. |
+| [General reference entry](https://github.com/thegooddocsproject/templates/blob/dev/reference/about-reference.md) | Reference | Specific details about a particular topic |
+| [Logging reference](https://github.com/thegooddocsproject/templates/blob/dev/logging/about-logging.md) | Reference | Description of log pipelines |
 
 ## The cookbook
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Current templates:
 
 | Template name | Documentation type | Description |
 | ------------- | ------------------ | ----------- |
-| [API Project overview](https://github.com/thegooddocsproject/templates/blob/dev/api-overview/about-overview.md) | Concept | An overview of your API |
+| [API Project overview](about-overview.md) | Concept | An overview of your API |
 | [API Quickstart](https://github.com/thegooddocsproject/templates/blob/dev/api-quickstart/about-quickstart.md) | Concept, Task | Simplest possible method of implementing your API |
 | [API Reference](https://github.com/thegooddocsproject/templates/blob/dev/api-reference/about-api-reference.md) | Reference | List of references related to your API |
 | [Explanation](https://github.com/thegooddocsproject/templates/blob/dev/explanation/about-explanation.md) | Concept | Longer document giving background or context to a topic |


### PR DESCRIPTION
I added links to the individual about pages of each template type listed in the Readme for easier navigation. 
This way, users who land on the readme can easily locate the individual templates without having to dig through files in the repo. 

I think the next thing to do would be to add links to each template file in their respective about pages too.

